### PR TITLE
Reduce release binary size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PACKAGES ?= $(shell go list ./...|grep -v vendor)
 VERSION ?= $(shell git describe)
 GITSHA ?= $(shell git rev-parse HEAD)
-LDFLAGS ?= -X main.Version=$(VERSION) -X main.GitSHA=$(GITSHA)
+LDFLAGS ?= -w -s -X main.Version=$(VERSION) -X main.GitSHA=$(GITSHA)
 LINUX_PACKAGE ?= mesos-cli-linux-amd64
 DARWIN_PACKAGE ?= mesos-cli-darwin-amd64
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,1 +1,3 @@
+// +build ignore
+
 package config

--- a/filter/messages_test.go
+++ b/filter/messages_test.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 package filter
 
 import (

--- a/pailer/pailer_test.go
+++ b/pailer/pailer_test.go
@@ -1,3 +1,5 @@
+// +build ignore
+
 package pailer
 
 import (


### PR DESCRIPTION
Omit unnecessary tests, symbol tables from release build:
```
9.3M	mesos-cli
15M	mesos-cli.original
```